### PR TITLE
Remove iAd support in favour of AdSupport framework

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -70,7 +70,6 @@
         </pods-config>
         <pod id="Analytics" version="3.5.5" />
         <framework src="AdSupport.framework" />
-        <framework src="iAd.framework" />
     </platform>
 
 </plugin>


### PR DESCRIPTION
I believe there is no need of iAdSupport framework as suggested here all we need is AdSupport framework - https://segment.com/docs/integrations/tune/#ios-setup

Less library will result in faster app startup.