### PR TITLE
Made all the methods execute asynchronously

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-segment",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Cordova plugin for Segment Analytics",
   "repository": {
     "type": "git",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="cordova-plugin-segment" version="0.0.2">
+    id="cordova-plugin-segment" version="0.2.0">
     <name>AnalyticsPlugin</name>
     <description>Cordova Plugin Segment</description>
     <license>MIT License</license>
@@ -50,6 +50,7 @@
         <framework src="com.segment.analytics.android:analytics:4.2.6"/>
 
         <source-file src="src/android/AnalyticsPlugin.java" target-dir="src/com/segment/analytics/cordova"/>
+        <source-file src="src/android/AnalyticsPluginHelper.java" target-dir="src/com/segment/analytics/cordova"/>
     </platform>
 
     <platform name="ios">

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -2,6 +2,7 @@ package com.segment.analytics.cordova;
 
 import android.util.Log;
 
+import com.segment.analytics.Analytics;
 import com.segment.analytics.Properties;
 import com.segment.analytics.Properties.Product;
 import com.segment.analytics.StatsSnapshot;
@@ -47,7 +48,7 @@ public class AnalyticsPlugin extends CordovaPlugin {
 
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
-        if (analyticsPluginHelper == null || analyticsPluginHelper.getAnalytics() == null) {
+        if (analyticsPluginHelper == null) {
             Log.e(TAG, "Error initializing");
             return false;
         }
@@ -80,9 +81,19 @@ public class AnalyticsPlugin extends CordovaPlugin {
         return false;
     }
 
+    private Boolean isAnalyticsSingeltonSet() {
+        if(analyticsPluginHelper.getAnalytics() == null) {
+            Log.e(TAG, "Error initializing");
+            return false;
+        }
+        return true;
+    }
+
     private void identify(JSONArray args) {
         cordova.getThreadPool().execute(() -> {
-            analyticsPluginHelper.getAnalytics().with(cordova.getActivity().getApplicationContext()).identify(
+            if(!isAnalyticsSingeltonSet()) return;
+
+            Analytics.with(cordova.getActivity().getApplicationContext()).identify(
                     optArgString(args, 0),
                     makeTraitsFromJSON(args.optJSONObject(1)),
                     null // passing options is deprecated
@@ -92,7 +103,9 @@ public class AnalyticsPlugin extends CordovaPlugin {
 
     private void group(JSONArray args) {
         cordova.getThreadPool().execute(() -> {
-            analyticsPluginHelper.getAnalytics().with(cordova.getActivity().getApplicationContext()).group(
+            if(!isAnalyticsSingeltonSet()) return;
+
+            Analytics.with(cordova.getActivity().getApplicationContext()).group(
                     optArgString(args, 0),
                     makeTraitsFromJSON(args.optJSONObject(1)),
                     null // passing options is deprecated
@@ -102,7 +115,9 @@ public class AnalyticsPlugin extends CordovaPlugin {
 
     private void track(JSONArray args) {
         cordova.getThreadPool().execute(() -> {
-            analyticsPluginHelper.getAnalytics().with(cordova.getActivity().getApplicationContext()).track(
+            if(!isAnalyticsSingeltonSet()) return;
+
+            Analytics.with(cordova.getActivity().getApplicationContext()).track(
                     optArgString(args, 0),
                     makePropertiesFromJSON(args.optJSONObject(1)),
                     null // passing options is deprecated
@@ -112,7 +127,9 @@ public class AnalyticsPlugin extends CordovaPlugin {
 
     private void screen(JSONArray args) {
         cordova.getThreadPool().execute(() -> {
-            analyticsPluginHelper.getAnalytics().with(cordova.getActivity().getApplicationContext()).screen(
+            if(!isAnalyticsSingeltonSet()) return;
+
+            Analytics.with(cordova.getActivity().getApplicationContext()).screen(
                     optArgString(args, 0),
                     optArgString(args, 1),
                     makePropertiesFromJSON(args.optJSONObject(2)),
@@ -123,7 +140,9 @@ public class AnalyticsPlugin extends CordovaPlugin {
 
     private void alias(JSONArray args) {
         cordova.getThreadPool().execute(() -> {
-            analyticsPluginHelper.getAnalytics().with(cordova.getActivity().getApplicationContext()).alias(
+            if(!isAnalyticsSingeltonSet()) return;
+
+            Analytics.with(cordova.getActivity().getApplicationContext()).alias(
                     optArgString(args, 0),
                     null // passing options is deprecated
             );
@@ -132,19 +151,25 @@ public class AnalyticsPlugin extends CordovaPlugin {
 
     private void reset() {
         cordova.getThreadPool().execute(() -> {
-            analyticsPluginHelper.getAnalytics().with(cordova.getActivity().getApplicationContext()).reset();
+            if(!isAnalyticsSingeltonSet()) return;
+
+            Analytics.with(cordova.getActivity().getApplicationContext()).reset();
         });
     }
 
     private void flush() {
         cordova.getThreadPool().execute(() -> {
-            analyticsPluginHelper.getAnalytics().with(cordova.getActivity().getApplicationContext()).flush();
+            if(!isAnalyticsSingeltonSet()) return;
+
+            Analytics.with(cordova.getActivity().getApplicationContext()).flush();
         });
     }
 
     private void getSnapshot(CallbackContext callbackContext) {
         cordova.getThreadPool().execute(() -> {
-            StatsSnapshot snapshot = analyticsPluginHelper.getAnalytics()
+            if(!isAnalyticsSingeltonSet()) return;
+
+            StatsSnapshot snapshot = Analytics
                     .with(cordova.getActivity().getApplicationContext()).getSnapshot();
             JSONObject snapshotJSON = new JSONObject();
 

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -47,7 +47,7 @@ public class AnalyticsPlugin extends CordovaPlugin {
 
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
-        if (analyticsPluginHelper.getAnalytics() == null) {
+        if (analyticsPluginHelper == null || analyticsPluginHelper.getAnalytics() == null) {
             Log.e(TAG, "Error initializing");
             return false;
         }

--- a/src/android/AnalyticsPluginHelper.java
+++ b/src/android/AnalyticsPluginHelper.java
@@ -1,0 +1,98 @@
+package com.segment.analytics.cordova;
+
+import android.content.Context;
+import android.util.Log;
+
+import com.segment.analytics.Analytics;
+
+import org.apache.cordova.CordovaPreferences;
+
+import java.lang.ref.WeakReference;
+
+public class AnalyticsPluginHelper implements Runnable {
+
+    private volatile Analytics analytics;
+    private CordovaPreferences preferences;
+    private static final String TAG = "AnalyticsPlugin";
+    private WeakReference<Context> contextWeakReference;
+    private Boolean isPluginError = false;
+    private String packageName;
+
+    public AnalyticsPluginHelper(CordovaPreferences preferences, Context context, String packageName) {
+        this.preferences = preferences;
+        contextWeakReference = new WeakReference<>(context);
+        this.packageName = packageName;
+    }
+
+    public Analytics getAnalytics() {
+        while(analytics==null && !isPluginError) {
+//            Uncomment below line if Android ever gets java 9 support
+//            Thread.onSpinWait();
+        }
+        return analytics;
+    }
+
+    @Override
+    public void run() {
+        String writeKeyPreferenceName;
+        Analytics.LogLevel logLevel;
+
+        if (packageName.equals("com.shipt.groceries_staging")) {
+            writeKeyPreferenceName = "shipt_analytics_android_debug_write_key";
+            logLevel = Analytics.LogLevel.VERBOSE;
+        } else if (packageName.equals("com.shipt.groceries")) {
+            writeKeyPreferenceName = "shipt_analytics_android_write_key";
+            logLevel = Analytics.LogLevel.NONE;
+        }else if (packageName.equals("com.shipt.meijerstaging")) {
+            writeKeyPreferenceName = "meijer_analytics_android_debug_write_key";
+            logLevel = Analytics.LogLevel.VERBOSE;
+        } else if (packageName.equals("com.shipt.meijer")) {
+            writeKeyPreferenceName = "meijer_analytics_android_write_key";
+            logLevel = Analytics.LogLevel.NONE;
+        } else if (packageName.equals("com.shipt.shopper_staging")) {
+            writeKeyPreferenceName = "shopper_analytics_android_debug_write_key";
+            logLevel = Analytics.LogLevel.VERBOSE;
+        } else if (packageName.equals("com.shipt.shopper-staging")) {
+            writeKeyPreferenceName = "shopper_analytics_android_debug_write_key";
+            logLevel = Analytics.LogLevel.VERBOSE;
+        } else if (packageName.equals("com.shipt.shopper")) {
+            writeKeyPreferenceName = "shopper_analytics_android_write_key";
+            logLevel = Analytics.LogLevel.NONE;
+        } else {
+            writeKeyPreferenceName = "";
+            logLevel = Analytics.LogLevel.VERBOSE;
+        }
+
+        String writeKey = preferences.getString(writeKeyPreferenceName, null);
+
+        if (writeKey == null || "".equals(writeKey)) {
+            analytics = null;
+            Log.e(TAG, "Invalid write key: " + writeKey);
+            isPluginError = true;
+        } else {
+            //trackApplicationLifecycleEvents() //-> Enable this to record certain application events automatically! -> which then used by Tune to map install attributions https://segment.com/docs/sources/mobile/android/quickstart/#step-2-initialize-the-client
+
+            // trackApplicationLifecycleEvents - is not getting fired due to ` segment` initializing is getting done on onActivityStarted instead on onActivityCreated. Where segment logic of `trackApplicationLifecycleEvents` is handled with in `onActivityCreated` https://github.com/segmentio/analytics-android/blob/master/analytics/src/main/java/com/segment/analytics/Analytics.java#L291
+
+            // analytics = new Analytics.Builder(
+            //     cordova.getActivity().getApplicationContext(),
+            //     writeKey
+            // )
+            // .logLevel(logLevel)
+            // .collectDeviceId(true)
+            // .trackApplicationLifecycleEvents()
+            // .build();
+
+            analytics = new Analytics.Builder(
+                    contextWeakReference.get(),
+                    writeKey
+            )
+                    .logLevel(logLevel)
+                    .collectDeviceId(true)
+                    .trackApplicationLifecycleEvents()
+                    .build();
+
+            Analytics.setSingletonInstance(analytics);
+        }
+    }
+}


### PR DESCRIPTION
| Status  | Type  |
| :---: | :---: |
| Ready| Chore |

## Description

### Problem
_The Analytics plugin was being initialized on the main thread, and was causing the application to skip frames. Additionally, some of the methods were also called multiple times in succession at times like scrolling (possible force closes on slower devices)_

### Fix
Initialize the plugin asynchronously and make the getter method for the Analytics object blocking until plugin is initialized. Also, made other operations (screen, track, etc.) that could be done in the background asynchronous. 

## Before & After Screenshots

**BEFORE**:
![screen shot 2018-09-04 at 1 28 47 pm](https://user-images.githubusercontent.com/4908901/45058617-06a1ba00-b04e-11e8-9bbf-b3e215c65b27.png)
![screen shot 2018-09-04 at 9 59 40 am](https://user-images.githubusercontent.com/4908901/45058541-d823df00-b04d-11e8-8b9a-a73129edaca1.png)

**AFTER**:
![screen shot 2018-09-04 at 1 13 42 pm](https://user-images.githubusercontent.com/4908901/45058627-0f928b80-b04e-11e8-8b6d-f1d0930a5aa4.png)
![screen shot 2018-09-04 at 12 21 49 pm](https://user-images.githubusercontent.com/4908901/45058633-15886c80-b04e-11e8-9008-d002e0ac81ad.png)
